### PR TITLE
corrected a step in the in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Our Model performs fairly well with an accuracy of 95% and an F1 Score of 95% an
 2. Clone the Repo by going to your local Git Client and pushing in the command: 
 
 ```sh
-https://github.com/HarshCasper/Malaria-Detection.git
+git clone https://github.com/HarshCasper/Malaria-Detection.git
 ```
 
 3. Install the Packages: 


### PR DESCRIPTION
We need to add git clone before the link of the repo in order to clone the repo down locally

Maybe it went unnoticed. So in this pull request I added the proper command